### PR TITLE
Revert "fix(deps): update dependency org.eclipse.jetty:jetty-server to v9.4.56.v20240826 [security]"

### DIFF
--- a/cirras-underwriting-api/pom.xml
+++ b/cirras-underwriting-api/pom.xml
@@ -198,7 +198,7 @@
 			<dependency>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-server</artifactId>
-				<version>9.4.56.v20240826</version>
+				<version>9.4.28.v20200408</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.jetty</groupId>

--- a/cirras-underwriting-war/pom.xml
+++ b/cirras-underwriting-war/pom.xml
@@ -257,7 +257,7 @@
 			<dependency>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-server</artifactId>
-				<version>9.4.56.v20240826</version>
+				<version>9.4.28.v20200408</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
Reverts bcgov/nr-brmb-pim#198