### PR TITLE
Revert "fix(deps): update dependency org.eclipse.jetty:jetty-webapp to v9.4.33.v20201020 [security]"

### DIFF
--- a/cirras-underwriting-api/pom.xml
+++ b/cirras-underwriting-api/pom.xml
@@ -208,7 +208,7 @@
 			<dependency>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-webapp</artifactId>
-				<version>9.4.33.v20201020</version>
+				<version>9.4.28.v20200408</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.jetty</groupId>

--- a/cirras-underwriting-war/pom.xml
+++ b/cirras-underwriting-war/pom.xml
@@ -267,7 +267,7 @@
 			<dependency>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-webapp</artifactId>
-				<version>9.4.33.v20201020</version>
+				<version>9.4.28.v20200408</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
Reverts bcgov/nr-brmb-pim#199